### PR TITLE
[OD-1344]Added check to only apply deletion logic to files that end in SQL

### DIFF
--- a/s3-autodelete.sh
+++ b/s3-autodelete.sh
@@ -39,7 +39,7 @@ AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KE
             continue
         fi
     else
-      echo "$createDate skipped because not a file";
+      echo "$line skipped because not a suppoorted file or is a folder";
       continue    
     fi
 done;

--- a/s3-autodelete.sh
+++ b/s3-autodelete.sh
@@ -7,7 +7,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dateToday=`date`
-regexEndsInSql='^.*\.(sql)$'
+regexEndsInSql='^.*\.sql$'
 
 source $DIR/secrets.conf
 

--- a/s3-autodelete.sh
+++ b/s3-autodelete.sh
@@ -6,28 +6,40 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-date_today=`date`
+dateToday=`date`
+regexEndsInSql='^.*\.(sql)$'
 
 source $DIR/secrets.conf
 
 # Maximum date (will delete all files older than this date)
-maxDate=`[ "$(uname)" = Linux ] && date --date="${date_today} -${2} day" +%Y-%m-%d" "%T`
+maxDate=`[ "$(uname)" = Linux ] && date --date="${dateToday} -${2} day" +%Y-%m-%d" "%T`
 maxDate=`date -d"$maxDate" +%s`
 
 # Loop thru files
 AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws s3 ls s3://$1/ | while read -r line;  do
     # Get file creation date
     createDate=`echo $line|awk {'print $1" "$2'}`
-    createDate=`date -d"$createDate" +%s`
 
-    if [[ $createDate -lt $maxDate ]]
+    if [[ $line =~ $regexEndsInSql ]];
     then
+        createDateCompare=`date -d"$createDate" +%s`
         # Get file name
         fileName=`echo $line|awk {'print $4'}`
-        if [[ $fileName != "" ]]
+
+        if [[ $createDateCompare -lt $maxDate ]];
         then
-            echo "* Delete $fileName";
-            AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  aws s3 rm s3://$1/$fileName
+            if [[ $fileName != "" ]]
+            then
+                echo "* Delete $fileName";
+                AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  aws s3 rm s3://$1/$fileName
+                continue
+            fi
+        else
+            echo "$fileName skipped because it is not older than deletion date: $createDate";
+            continue
         fi
+    else
+      echo "$createDate skipped because not a file";
+      continue    
     fi
 done;


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [OD-1344](https://opengovinc.atlassian.net/browse/OD-1344)

## Description
<!--- Describe these changes in detail --->
In this PR, a check is being added to make sure when we're reading through the backups/ to only apply deletion logic to files ending in `.sql` extension.

## Test Procedure
<!--- List the steps involved to test the changes --->
Verify `s3-autodelte.sh` is working properly
1. bash into pod `performance-dashboards-5899858d94-46v7c` and go into the following directory `/tmp/pg_dump-to-s3`
2. git checkout to this branch `javier-tello23/OD-1344/2019-07-18/fix-in-autodelete-scripts`
3. run script `. s3-autodelete.sh <path-to-bucket> <days-to-delete-files>` and make sure script completes and prints out messages. If you do not know the path to bucket, contact me.


## Approval Criteria 
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
